### PR TITLE
Add description meta tag

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -36,6 +36,7 @@ export default function App() {
       <head>
         <meta charSet="utf-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta name="description" content="No chips, no cards, no table? Play poker with your friends and family - we've got the accessories.">
         <title>flop. poker - the mobile game</title>
 
         <link rel="preconnect" href="https://fonts.googleapis.com" />


### PR DESCRIPTION
Adding a meta tag for description to improve search (if google is interested)

Copy is just a first draft, not married to it 🫠 

Mostly just trying to get keywords in - poker, "no chips", "no cards", family, friends... etc, might be other words to include I missed? 

https://www.link-assistant.com/news/html-tags-for-seo.html#2-Meta-description-tag9 - 160 characters is apparently the amount to stay below - this is ~100